### PR TITLE
Fix inccored example in the surface-shaders.mdx file

### DIFF
--- a/docs/visionary-render-programming/shaders/surface-shaders.mdx
+++ b/docs/visionary-render-programming/shaders/surface-shaders.mdx
@@ -248,8 +248,8 @@ uniform vec2 MyVec2;
 uniform vec3 MyVec3;
 uniform vec4 MyVec4;
 uniform vec3 MyColour;
-uniform sampler2d MyTex2D;
-uniform sampler3d MyTex3D;
+uniform sampler2D MyTex2D;
+uniform sampler3D MyTex3D;
 uniform samplerCube MyTexCube;
 ```
 


### PR DESCRIPTION
It should have been sampler2D not sampler2d same for 3D